### PR TITLE
Fix memory leak and specify library language

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A fast and space-efficient library for handling combinational Boolean circuits composed of the following types of gates:
+A fast and space-efficient C library for handling combinational Boolean circuits composed of the following types of gates:
 - NAND, AND, OR, NOR, XOR, XNOR
 
 

--- a/example.c
+++ b/example.c
@@ -36,6 +36,7 @@ static int example(void) {
     gate_delete(g0);
     gate_delete(g1);
     gate_delete(g2);
+    gate_delete(g4);
 
     return 0;
 }


### PR DESCRIPTION
- Fix a memory leak in `example.c` by adding a call to `gate_delete` for `g4`
- Update README.md to specify that this is a C library